### PR TITLE
causes DEPRECATION WARNING on spec

### DIFF
--- a/lib/skeleton-rails/rails/engine.rb
+++ b/lib/skeleton-rails/rails/engine.rb
@@ -3,10 +3,6 @@ require 'rails'
 module SkeletonRails
   module Rails
     class Engine < ::Rails::Engine
-      initializer 'skeleton-rails.setup', 
-        :group => :all do |app|
-          app.config.paths << File.join(config.root, 'vendor')
-      end
     end
   end
 end


### PR DESCRIPTION
DEPRECATION WARNING: Accessing paths using dot style as in `config.paths.app.controller` is deprecated.
