### PR TITLE
Fix for Rails 3.2

### DIFF
--- a/lib/skeleton-rails/rails/engine.rb
+++ b/lib/skeleton-rails/rails/engine.rb
@@ -5,7 +5,7 @@ module SkeletonRails
     class Engine < ::Rails::Engine
       initializer 'skeleton-rails.setup', 
         :group => :all do |app|
-          app.config.paths << File.join(config.root, 'vendor')
+          app.paths["config"] << File.join(config.root, 'vendor')
       end
     end
   end


### PR DESCRIPTION
Hey guys, thanks for putting skeleton into a plugin.

One problem in Rails 3.2

~/code/rails32# rails g skeleton:install
/usr/local/rvm/gems/ruby-1.9.2-p180/gems/skeleton-rails-0.0.1/lib/skeleton-rails/rails/engine.rb:8:in `block in <class:Engine>': undefined method`<<' for #Rails::Paths::Root:0xa0c0878 (NoMethodError)

This change seems to fix it, and also works in Rails 3.1

Cheers
