### PR TITLE
Generator fix for Rails 4.

### DIFF
--- a/lib/generators/skeleton/install/install_generator.rb
+++ b/lib/generators/skeleton/install/install_generator.rb
@@ -1,7 +1,9 @@
 require 'rails/generators'
 require 'rails'
 
-if ::Rails.version < "3.1" || !::Rails.application.config.assets.enabled
+if ::Rails.version < "3.1" || 
+   (::Rails.version < "4.0" && !::Rails.application.config.assets.enabled) ||
+   (::Rails.version >= "4.0" && !(::Rails.application.config.assets.enabled.nil? || ::Rails.application.config.assets.enabled))
   module Skeleton
     module Generators
       class InstallGenerator < ::Rails::Generators::Base


### PR DESCRIPTION
Rails 4 has changed how to determine if the asset pipeline is installed. Previous to this fix, skeleton-rails would not install.

See: 

https://github.com/rails/rails/issues/10334
https://github.com/apneadiving/Google-Maps-for-Rails/pull/359/files

I've tested this with Rails 4-stable and it works.