### PR TITLE
Fixed Typo in the version number in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ __Rails >= 4 is required.__
 Add to your `Gemfile`:
 
 ```ruby
-gem 'skeleton-rails', '~> 1.0'
+gem 'skeleton-rails', '~> 0.1.0'
 ```
 
 then run `bundle` in the console, and then run:


### PR DESCRIPTION
The README instruction to install version 1.0 does not match the tags in Github. 
Correcting to 0.1.0 works.

Alternatively, the version number could be removed altogether which would mean future updates wouldn't need the documentation fixed each time.